### PR TITLE
[Dev Docs] Add clarification on Query Params with Nexo sync

### DIFF
--- a/docs/developer-tools/nexo.md
+++ b/docs/developer-tools/nexo.md
@@ -74,6 +74,7 @@ function App() {
 ### Ativar a sincronização de rotas
 
 Essa funcionalidade permitirá que você registre a navegação do aplicativo na URL do navegador por meio de fragmentos (#myroute).
+> Importante: A sincronização permite obter o PATH mas não é possível para Query Params.
 
 Este exemplo é feito com o [React Router](https://reactrouter.com/en/main).
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/developer-tools/nexo.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/developer-tools/nexo.md
@@ -74,6 +74,7 @@ function App() {
 ### Enable route synchronization
 
 This functionality will allow you to record the app navigation of your app in the browser URL via fragment (#myroute)
+> Important: Synchronization allows obtaining the PATH but it is not possible for the Query Params.
 
 This example is made with [React Router](https://reactrouter.com/en/main).
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/developer-tools/nexo.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developer-tools/nexo.md
@@ -74,6 +74,7 @@ function App() {
 ### Habilitar la sincronización de rutas
 
 Esta funcionalidad te permitirá registrar la navegación de la aplicación en la URL del navegador a través de fragmentos (#myroute).
+> Importante: La sincronización permite obtener el PATH pero no es posible para los Query Params.
 
 Este ejemplo está hecho con [React Router](https://reactrouter.com/en/main).
 


### PR DESCRIPTION
- Modify the docs in three languages (en, es, pt).

EN
> Important: Synchronization allows obtaining the PATH but it is not possible for the Query Params.

ES
> Importante: La sincronización permite obtener el PATH pero no es posible para los Query Params.

PT
> Importante: A sincronização permite obter o PATH mas não é possível para Query Params.