### PR TITLE
docs(NubeSDK): add navigation API docs and NubeSDK Assistant

### DIFF
--- a/docs/applications/nube-sdk/browser-apis.md
+++ b/docs/applications/nube-sdk/browser-apis.md
@@ -6,7 +6,7 @@ title: Browser API's
 This SDK is a Work In Progress! All features are subject to change.
 :::
 
-By default, the WebWorks runtime in the browser does not provide direct access to [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) or [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). These APIs are part of the main thread’s window context and are not natively available inside web workers.
+By default, the WebWorks runtime in the browser does not provide direct access to [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) or [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). These APIs are part of the main thread's window context and are not natively available inside web workers.
 
 To overcome this limitation and enable NubeSDK applications to use these storage APIs transparently, the NubeSDK includes an internal mechanism that exposes both `localStorage` and `sessionStorage` within the worker environment.
 
@@ -14,7 +14,7 @@ To overcome this limitation and enable NubeSDK applications to use these storage
 
 The `nube` object exposes a method called `getBrowserAPIs`, which returns an interface with support for asynchronous access to browser APIs. These include `asyncLocalStorage` and `asyncSessionStorage`, which return promises for use within asynchronous contexts.
 
-## How to Use
+### How to Use
 
 The next example uses the `setItem` method from `asyncSessionStorage` to store a new value.
 
@@ -44,12 +44,11 @@ export function App(nube: NubeSDK) {
 }
 ```
 
-## Time To Live
+### Time To Live
 
 Both `asyncLocalStorage` and `asyncSessionStorage` support an optional third parameter called `ttl` (time-to-live), which defines how long the stored value should remain valid, in seconds.
 
 When provided, the `ttl` determines the expiration time for the key. Once the specified duration has passed, the value will no longer be accessible via `getItem`, and it will be treated as if it were removed.
-
 
 ```typescript title="main.ts"
 // Store a value that expires in 60 seconds
@@ -60,3 +59,32 @@ If no `ttl` is provided, the value will persist indefinitely, following the defa
 
 - Learn more about [UI Components](./ui-components)
 - Learn more about [UI Slots](./ui-slots)
+
+## navigate
+
+The `nube` object also provides a `navigate` method through the `getBrowserAPIs()` interface, which allows you to programmatically navigate to different routes within your Nube app.
+
+### How to Use
+
+The `navigate` method accepts a path string as its parameter and returns void.
+
+```typescript title="main.ts"
+import type { NubeSDK } from "@tiendanube/nube-sdk-types";
+
+export function App(nube: NubeSDK) {
+	const browser = nube.getBrowserAPIs();
+
+	// Navigate to a specific route
+	browser.navigate("/products");
+	console.log("Navigation initiated");
+}
+```
+
+The `navigate` method is particularly useful when you need to:
+- Redirect users after completing certain actions
+- Implement custom navigation logic in your application
+- Handle programmatic navigation based on user interactions
+
+:::warning
+The `navigate` method only allows navigation within the current domain and does not support external URLs or cross-origin navigation.
+:::

--- a/docs/applications/nube-sdk/getting-started.md
+++ b/docs/applications/nube-sdk/getting-started.md
@@ -190,6 +190,17 @@ If development mode is active, an object similar to the following will be return
 
 Ensure that the script attribute of your app contains the URL localhost. This confirms that the environment is properly set up for development.
 
+## NubeSDK Assistant
+
+The NubeSDK Assistant is a specialized ChatGPT-powered tool designed to help developers create and build apps using the NubeSDK. This assistant provides:
+
+- Expert guidance on NubeSDK implementation
+- Code examples and best practices
+- Troubleshooting support
+- Step-by-step assistance in app development
+
+You can access the NubeSDK Assistant at: [NubeSDK Assistant](https://chatgpt.com/g/g-6812298534c88191be0705ba82fea093-nubesdk-assistant)
+
 ## Next Steps
 
 - Learn more about [Script Structure](./script-structure)


### PR DESCRIPTION
# Add Navigation API Documentation

## Changes
- Added documentation for the `browser.navigate()` method in browser-apis.md
- Added NubeSDK Assistant section in getting-started.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated browser APIs documentation with a new section on the navigate method, including usage examples and limitations.
  - Improved heading structure and fixed a minor typographic issue.
  - Added a new section introducing the NubeSDK Assistant, highlighting its features and providing access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->