### PR TITLE
fix: example code of coupon:add event

### DIFF
--- a/docs/applications/nube-sdk/events.md
+++ b/docs/applications/nube-sdk/events.md
@@ -163,9 +163,11 @@ Dispatched by `app` to add a coupon code to the cart.
 
 ```typescript
 nube.send("coupon:add", () => ({
-  coupon: {
-    code: "SUMMER2024"
-  }
+  cart: {
+    coupon: {
+      code: "SUMMER2024",
+    },
+  },
 }));
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/applications/nube-sdk/events.md` file. The change updates the structure of the `coupon:add` event payload to nest the `coupon` object within a `cart` object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the event payload structure for the `coupon:add` event to reflect the new data hierarchy, nesting the coupon code within a `cart` object for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->