### PR TITLE
fix: broken documentation links

### DIFF
--- a/docs/applications/nube-sdk/components/image.md
+++ b/docs/applications/nube-sdk/components/image.md
@@ -9,7 +9,7 @@ import AppTypes from '@site/src/components/AppTypes';
 This SDK is a Work In Progress! All features are subject to change.
 :::
 
-We support multiple UI components built in JSX, some of which support nesting, to enable the creation of rich user interfaces. The UI components are assigned to [slots](./ui-slots) by sending the [ui:slot:set](./events#uislotset) event.
+We support multiple UI components built in JSX, some of which support nesting, to enable the creation of rich user interfaces. The UI components are assigned to [slots](../ui-slots) by sending the [ui:slot:set](../events#uislotset) event.
 
 Used to display images. It supports properties such as `src`, `alt`, `width`, `height`, and responsive `sources` for different screen sizes.
 

--- a/docs/erp-guide/overview.md
+++ b/docs/erp-guide/overview.md
@@ -480,7 +480,7 @@ Os produtos com variação utilizam os conceitos de **attributes** (atributos) e
 
 Use este endpoint para criar um novo produto na loja.
 
-[Requisição de exemplo:]((https://tiendanube.github.io/api-documentation/resources/product))
+[Requisição de exemplo:](https://tiendanube.github.io/api-documentation/resources/product)
 
 ```bash
 curl -X POST https://api.nuvemshop.com/v1/{{store_id}}/products \

--- a/i18n/en/docusaurus-plugin-content-docs/current/erp-guide/overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/erp-guide/overview.md
@@ -475,7 +475,7 @@ Products with variation use the concepts of **attributes** and **values**:
 
 Use this endpoint to create a new product in the store.
 
-[Example request:]((https://tiendanube.github.io/api-documentation/resources/product))
+[Example request:](https://tiendanube.github.io/api-documentation/resources/product)
 
 ```bash
 curl -X POST https://api.nuvemshop.com/v1/{{store_id}}/products \


### PR DESCRIPTION
This pull request includes minor corrections to documentation links to ensure proper formatting and functionality.

Documentation fixes:

* [`docs/applications/nube-sdk/components/image.md`](diffhunk://#diff-76aca0a78ffc529221a6211fb08b9da90e601cf41d416fb95ebe1adb638f871fL12-R12): Updated relative links for `ui-slots` and `ui:slot:set` to use the correct path format (`../ui-slots` and `../events#uislotset`).
* [`docs/erp-guide/overview.md`](diffhunk://#diff-210011692d12b777dda20c3b72564403cec2068533db687363b743effe57879fL483-R483): Fixed the formatting of the "Example request" link by removing redundant parentheses.
* [`i18n/en/docusaurus-plugin-content-docs/current/erp-guide/overview.md`](diffhunk://#diff-15c073b539aca284a21dd03e976f2c5688f4bc798cefe1c734b2c00e06413ea6L478-R478): Corrected the "Example request" link formatting by removing extra parentheses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links for UI component slot assignment events to ensure correct navigation.
  - Fixed Markdown syntax errors in documentation links for improved readability and proper rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->