### PR TITLE
feat(NubeSDK): add accordion component from nube-sdk documentation

### DIFF
--- a/docs/applications/nube-sdk/components.md
+++ b/docs/applications/nube-sdk/components.md
@@ -41,6 +41,11 @@ A component for rendering text with optional styling, supporting properties like
 ### [Image](/docs/applications/nube-sdk/components/image)
 A component for displaying images with support for responsive sources, alternative text, and various sizing options.
 
+## Interactive Components
+
+### [Accordion](/docs/applications/nube-sdk/components/accordion)
+A collapsible content component that allows users to expand and collapse sections of content, improving the user experience by reducing visual clutter.
+
 ## Key Features
 
 - **Theme Integration**: All components automatically adapt to the store's theme

--- a/docs/applications/nube-sdk/components/accordion.md
+++ b/docs/applications/nube-sdk/components/accordion.md
@@ -1,0 +1,74 @@
+---
+title: Accordion
+---
+
+import { Alert, Text, Box } from '@nimbus-ds/components';
+import AppTypes from '@site/src/components/AppTypes';
+
+:::warning
+This SDK is a Work In Progress! All features are subject to change.
+:::
+
+An `accordion` is a collapsible content component that allows users to expand and collapse sections of content. 
+It's commonly used to organize information into manageable sections, improving the user experience by reducing visual clutter.
+
+The accordion is a compound component composed of `Root`, `Item`, `Header`, and `Content` subcomponents.
+
+### Usage
+
+```typescript title="Example"
+import { Accordion } from "@tiendanube/nube-sdk-jsx";
+
+<Accordion.Root defaultValue="item-1" style={{ backgroundColor: "red" }}>
+  <Accordion.Item value="item-1">
+    <Accordion.Header showIcon>Accordion Item 1</Accordion.Header>
+    <Accordion.Content>Accordion Content 1</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="item-2">
+    <Accordion.Header>Accordion Item 2</Accordion.Header>
+    <Accordion.Content>Accordion Content 2</Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>;
+```
+
+## Subcomponents
+
+### Accordion.Root
+
+The root container that manages the accordion state.
+
+| Property     | Type                  | Required | Description                                          |
+| ------------ | --------------------- | -------- | ---------------------------------------------------- |
+| children     | NubeChildrenComponent | No       | Accordion items to be rendered.                      |
+| defaultValue | string                | No       | Default expanded item value.                         |
+| style        | StyleSheet            | No       | Custom styles for the accordion root.                |
+| id           | string                | No       | Optional unique identifier for the component.        |
+
+### Accordion.Item
+
+Individual accordion item container.
+
+| Property | Type                  | Required | Description                                          |
+| -------- | --------------------- | -------- | ---------------------------------------------------- |
+| children | NubeChildrenComponent | No       | Header and content components.                       |
+| id       | string                | No       | Optional unique identifier for the component.        |
+| style    | StyleSheet            | No       | Custom styles for the accordion item.                |
+
+### Accordion.Header
+
+The clickable header that toggles the accordion item.
+
+| Property | Type                  | Required | Description                                          |
+| -------- | --------------------- | -------- | ---------------------------------------------------- |
+| children | string                | No       | Text content of the header.                          |
+| showIcon | boolean               | No       | Whether to show expand/collapse icon.                |
+| style    | StyleSheet            | No       | Custom styles for the header.                        |
+
+### Accordion.Content
+
+The collapsible content area of the accordion item.
+
+| Property | Type                  | Required | Description                                          |
+| -------- | --------------------- | -------- | ---------------------------------------------------- |
+| children | NubeChildrenComponent | No       | Content to be displayed when item is expanded.       |
+| style    | StyleSheet            | No       | Custom styles for the content area.                  |

--- a/docs/applications/nube-sdk/components/overview.md
+++ b/docs/applications/nube-sdk/components/overview.md
@@ -45,6 +45,11 @@ A component for rendering text with optional styling, supporting properties like
 ### [Image](/docs/applications/nube-sdk/components/image)
 A component for displaying images with support for responsive sources, alternative text, and various sizing options.
 
+## Interactive Components
+
+### [Accordion](/docs/applications/nube-sdk/components/accordion)
+A collapsible content component that allows users to expand and collapse sections of content, improving the user experience by reducing visual clutter.
+
 ## Key Features
 
 - **Theme Integration**: All components automatically adapt to the store's theme

--- a/docs/applications/nube-sdk/components/row.md
+++ b/docs/applications/nube-sdk/components/row.md
@@ -9,8 +9,6 @@ import AppTypes from '@site/src/components/AppTypes';
 This SDK is a Work In Progress! All features are subject to change.
 :::
 
-## `Row`
-
 A `row` is a flexible horizontal container used to align child components in a row.
 It inherits all the capabilities of the [box component](/docs/applications/nube-sdk/components/box), with the direction property preset to `"row"`.
 


### PR DESCRIPTION
This pull request introduces a new `Accordion` component to the Nube SDK documentation and updates related files to include its details. The changes also improve the organization of the documentation by categorizing components under "Interactive Components."

### Addition of the `Accordion` Component

* [`docs/applications/nube-sdk/components/accordion.md`](diffhunk://#diff-78b9a6c5e34f275f9a79216abf02048e9c4f01aa54a817af83ce7c7ea6a72003R1-R74): Added a new file documenting the `Accordion` component, including its purpose, usage example, and detailed descriptions of its subcomponents (`Root`, `Item`, `Header`, `Content`).

### Updates to Component Documentation Structure

* [`docs/applications/nube-sdk/components.md`](diffhunk://#diff-ec5a0ec849a822c679baa2848ba25122d631585a45c46bf9e807a226dddd0833R44-R48): Added a new "Interactive Components" section with a link to the `Accordion` component documentation.
* [`docs/applications/nube-sdk/components/overview.md`](diffhunk://#diff-79bebb3aaf2860d8837d2bc1a8225c1cd7a1ed269e3e85c62f18733d1ed0b6d0R48-R52): Updated the overview file to include the "Interactive Components" section with a description of the `Accordion` component.

### Cleanup and Refinement

* [`docs/applications/nube-sdk/components/row.md`](diffhunk://#diff-2901b1f32a10b3b2210e814f59c8e2a9612dafc5255b102fbaf691d934862882L12-L13): Removed redundant header for the `Row` component to streamline the documentation.