### PR TITLE
chore: update cart:add event with product_id parameter

### DIFF
--- a/docs/applications/nube-sdk/events.md
+++ b/docs/applications/nube-sdk/events.md
@@ -117,6 +117,7 @@ nube.send("cart:add", () => ({
   cart: {
     items: [{
       variant_id: 123,
+      product_id: 321,
       quantity: 1,
     }]
   },
@@ -152,6 +153,7 @@ nube.send("cart:remove", () => ({
   cart: {
     items: [{
       variant_id: 123,
+      product_id: 321,
       quantity: 1,
     }]
   },


### PR DESCRIPTION
This pull request updates the documentation for the Nube SDK events to include the `product_id` field in the cart item structure for both the `cart:add` and `cart:remove` events. This ensures that each cart item now specifies both the `variant_id` and its associated `product_id`.

Documentation updates:

* Added the `product_id` field to the cart item example in the `cart:add` event documentation in `docs/applications/nube-sdk/events.md`.
* Added the `product_id` field to the cart item example in the `cart:remove` event documentation in `docs/applications/nube-sdk/events.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated events documentation for cart:add and cart:remove to include product_id in item payload examples, alongside variant_id and quantity.
  * Refreshed example payloads to reflect the updated shape shown in docs.
  * No functional or API changes; updates are documentation-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->